### PR TITLE
feature: 経費コントローラの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem 'mutex_m'
 # install ffi
 gem 'ffi'
 
+# install Serializer
+gem 'active_model_serializers'
+
 # install devise_token_auth
 gem 'devise'
 gem 'devise_token_auth'

--- a/app/controllers/api/v1/keihi_controller.rb
+++ b/app/controllers/api/v1/keihi_controller.rb
@@ -39,6 +39,29 @@ class Api::V1::KeihiController < ApplicationController
     render json: { error: e.message }, status: :internal_server_error
   end
 
+  # DELETE /api/v1/keihi/delete/:id
+  # 申請を削除する
+  def delete
+    @spend_request = SpendRequest.find(params[:id])
+    @spend_request.destroy
+    render json: { message: 'Record deleted' }, status: :ok
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Record not found' }, status: :not_found
+  end
+
+  # PUT /api/v1/keihi/update/:id
+  # 申請を更新する
+  def update
+    @spend_request = SpendRequest.find(params[:id])
+    if @spend_request.update(spend_request_params)
+      render json: @spend_request, status: :ok
+    else
+      render json: { errors: @spend_request.errors.full_messages }, status: :unprocessable_entity
+    end
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Record not found' }, status: :not_found
+  end
+
   private
 
   def spend_request_params

--- a/app/controllers/api/v1/keihi_controller.rb
+++ b/app/controllers/api/v1/keihi_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::KeihiController < ApplicationController
     render json: { error: 'Record not found' }, status: :not_found
   end
 
-  # POST /api/v1/keihi/get_by_user
+  # GET /api/v1/keihi/get_by_user
   # あるユーザーのすべての申請を取得する
   def get_by_user
     @spend_requests = SpendRequest.where(user_id: params[:user_id])

--- a/app/controllers/api/v1/keihi_controller.rb
+++ b/app/controllers/api/v1/keihi_controller.rb
@@ -1,0 +1,47 @@
+class Api::V1::KeihiController < ApplicationController
+  skip_before_action :authenticate_request
+
+  # GET /api/v1/keihi/index
+  # すべての申請を取得する
+  def index
+    @spend_requests = SpendRequest.all
+    render json: @spend_requests
+  end
+
+  # GET /api/v1/keihi/:id
+  # 特定の申請を取得する
+  def show
+    @spend_request = SpendRequest.find(params[:id])
+    render json: @spend_request
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Record not found' }, status: :not_found
+  end
+
+  # POST /api/v1/keihi/get_by_user
+  # あるユーザーのすべての申請を取得する
+  def get_by_user
+    @spend_requests = SpendRequest.where(user_id: params[:user_id])
+    render json: @spend_requests
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Record not found' }, status: :not_found
+  end
+
+  # POST /api/v1/keihi/create
+  # 申請を作成する
+  def create
+    @spend_request = SpendRequest.new(spend_request_params)
+    if @spend_request.save
+      render json: @spend_request, status: :created
+    else
+      render json: { errors: @spend_request.errors.full_messages }, status: :unprocessable_entity
+    end
+  rescue StandardError => e
+    render json: { error: e.message }, status: :internal_server_error
+  end
+
+  private
+
+  def spend_request_params
+    params.require(:spend_request).permit(:user_id, :status, :date_of_use, :amount, :spend_to, :keihi_class, :purpose, :invoice_number, :contact_number, :memo, :image_save)
+  end
+end

--- a/app/models/spend_request.rb
+++ b/app/models/spend_request.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+#
+# SpendRequest model
+#
+# This model is used to store the spend request data.
+#
+# Attributes:
+#   user_id: UUID
+#   status: string
+#   date_of_use: date
+#   amount: integer
+#   spend_to: text
+#   keihi_class: string
+#   purpose: text
+#   invoice_number: integer
+#   contact_number: integer
+#   memo: text
+#   image_save: text
+
+class SpendRequest < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,6 @@
 #  profile          :text
 #  role             :text
 class User < ApplicationRecord
+  has_many :spend_requests
+  has_many :user_authentications
 end

--- a/app/serializers/spend_request_serializer.rb
+++ b/app/serializers/spend_request_serializer.rb
@@ -1,0 +1,4 @@
+class SpendRequestSerializer < ActiveModel::Serializer
+  attributes :id, :status, :date_of_use, :amount, :spend_to, :user_id,
+  :keihi_class, :purpose, :invoice_number, :contact_number, :memo, :image_save
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,7 @@ module App
 
     # set services
     config.autoload_paths += %W(#{config.root}/app/services)
+    config.autoload_paths += %W(#{config.root}/app/serializers)
 
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore, key: '_cookie_name'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ namespace :api do
       # カレントユーザーの呼び出し
     post 'users/current', to: 'users#current'
     get 'csrf_token', to: 'csrf#token'
+    get 'keihi/show', to: 'keihi#show'
+    post 'keihi/create', to: 'keihi#create'
+    get 'keihi/index', to: 'keihi#index'
+    post 'keihi/get_by_user', to: 'keihi#get_by_user'
   end
 end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ namespace :api do
     get 'keihi/show', to: 'keihi#show'
     post 'keihi/create', to: 'keihi#create'
     get 'keihi/index', to: 'keihi#index'
-    post 'keihi/get_by_user', to: 'keihi#get_by_user'
+    get 'keihi/get_by_user', to: 'keihi#get_by_user'
     delete 'keihi/delete/:id', to: 'keihi#delete'
     put 'keihi/update/:id' , to: 'keihi#update'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ namespace :api do
     post 'keihi/create', to: 'keihi#create'
     get 'keihi/index', to: 'keihi#index'
     post 'keihi/get_by_user', to: 'keihi#get_by_user'
+    delete 'keihi/delete/:id', to: 'keihi#delete'
+    put 'keihi/update/:id' , to: 'keihi#update'
   end
 end
 end

--- a/db/migrate/20240823042743_create_spend_requests.rb
+++ b/db/migrate/20240823042743_create_spend_requests.rb
@@ -1,0 +1,22 @@
+class CreateSpendRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :spend_requests, id: :uuid do |t|
+      t.uuid :user_id, null: false # user id
+      t.string :status, null:false # accept status
+      t.date :date_of_use, null: false # date of use
+      t.integer :amount, null: false # spend  money
+      t.text :spend_to, null: false # 支払先
+      t.string :keihi_class, null: false # 経費科目
+      t.text :purpose, null: false # purpose
+      t.integer :invoice_number # 適格請求書番号
+      t.integer :contact_number # 連絡請求番号
+      t.text :memo # memo
+      t.text :image_save # file path of recipt image
+
+      t.timestamps
+    end
+
+    add_foreign_key :spend_requests, :users, column: :user_id
+    add_index :spend_requests, :user_id
+  end
+end

--- a/spec/models/spend_request_spec.rb
+++ b/spec/models/spend_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SpendRequest, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 修正・追加内容
---
- 経費の登録用のコントローラーを追加しました
- ValidationのためSerializerの導入も行っています

## 検証方法
---
- フロントがないのでuser_idをSQLで見つけてCurlで叩いてほしいです。
### 手順
1. docker composeをdown->build->up -dする
2. ブラウザでログイン処理をする
3. dbコンテナを開く
4. `psql -U postgres -d bigstar`
5. `select id from users`
6. `user_id`を5で拾ったIDに置き換えて以下のCurlコマンドをたたく
  - `create`だけ最初に叩く、あとは順不同

### 各Curlコマンド

- `localhost:3000/api/v1/keihi/create` 
```
curl -X POST http://localhost:3000/api/v1/keihi/create \
  -H "Content-Type: application/json" \
  -d '{
    "spend_request": {
      "user_id": "81aba0fc-0c3d-4ce1-8691-78ad4e57cb3d",
      "status": "pending",
      "date_of_use": "2024-08-23",
      "amount": 5000,
      "spend_to": "Office Supplies Inc.",
      "keihi_class": "office",
      "purpose": "Purchase of office supplies",
      "invoice_number": 12345,
      "contact_number": 67890,
      "memo": "Receipt attached",
      "image_save": "/path/to/receipt.jpg"
    }
  }'
```

- `localhost:3000/api/v1/keihi/show`
```
curl  -X POST localhost:3000/api/v1/keihi/get_by_user -H "Content-Type: application/json" -d '{ "user_id": "2e583074-f138-4cf0-93dd-4b6865f80788" }'
```

- `localhost:3000/api/v1/keihi/index`
```
curl  localhost:3000/api/v1/keihi/index
```

##  レビュしてほしいポイント
---
- Typeやいらないコードがないか
- Create処理やGet処理ができるか

## 特記事項
---