### PR TITLE
仮データ用のseed作成・react側での受け取りテスト実装

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,31 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+# 10人のユーザーをランダムに作成
+users = 10.times.map do |i|
+    User.create!(
+      id: SecureRandom.uuid, 
+      email: "user#{i + 1}@example.com",
+      name: "User #{i + 1}", 
+      profile: "This is the profile for User #{i + 1}.",
+      role: ['admin', 'employee', 'manager'].sample
+    )
+  end
+  
+  # Spend Requestsのテストデータをランダムなユーザーに関連付けて作成
+  20.times do |i|
+    SpendRequest.create!(
+      id: SecureRandom.uuid,
+      user_id: users.sample.id,
+      status: ['approved', 'pending', 'rejected'].sample,
+      date_of_use: Date.today - i.days,
+      amount: rand(1000..50000),
+      spend_to: "Vendor #{i + 1}",
+      keihi_class: ['交通費', '宿泊費', '接待費'].sample,
+      purpose: "Purpose of spend #{i + 1}",
+      invoice_number: rand(100000..999999),
+      contact_number: rand(10000..99999),
+      memo: "Memo for spend #{i + 1}",
+      image_save: "path/to/image#{i + 1}.jpg"
+    )
+  end

--- a/front/package.json
+++ b/front/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/axios": "^0.14.0",
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.4",
     "postcss": "^8.4.41",

--- a/front/src/components/SpendRequestFormComponent.tsx
+++ b/front/src/components/SpendRequestFormComponent.tsx
@@ -1,5 +1,3 @@
-
-
 /*
 ---DB input--------
 - 利用日
@@ -19,18 +17,18 @@
 - 不許可ボタン
 */
 
-const SpendRequestForm = () =>{
-    return (
-        <div className="w-screen bg-red-300">
-            <div className="h-1/6 bg-red-300">入力フォーム</div>
+const SpendRequestForm = () => {
+  return (
+    <div className="w-screen bg-red-300">
+      <div className="h-1/6 bg-red-300">入力フォーム</div>
 
-            <div className="h-4/6 bg-blue-300 flex">
-                <div className="bg-teal-100 w-1/2">left</div>
-                <div className="bg-teal-400 w-1/2">right</div>
-            </div>
-            <div className="h-1/6 bg-green-300">申請ボタンなど</div>
-        </div>
-    )
-}
+      <div className="h-4/6 bg-blue-300 flex">
+        <div className="bg-teal-100 w-1/2">left</div>
+        <div className="bg-teal-400 w-1/2">right</div>
+      </div>
+      <div className="h-1/6 bg-green-300">申請ボタンなど</div>
+    </div>
+  );
+};
 
-export default SpendRequestForm
+export default SpendRequestForm;

--- a/front/src/components/TestComponent.tsx
+++ b/front/src/components/TestComponent.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from "react";
+import { fetchApplications, Application } from "../hooks/useKeihi";
+
+export const ApplicationsPage: React.FC = () => {
+  const [Applications, setApplications] = useState<Application[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const getApplications = async () => {
+      try {
+        const data = await fetchApplications();
+        setApplications(data);
+      } catch (err) {
+        setError("Failed to fetch spend requests");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    getApplications();
+  }, []);
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>{error}</div>;
+
+  return (
+    <div>
+      <h1>Spend Requests</h1>
+      <ul>
+        {Applications.map((request) => (
+          <li key={request.id}>
+            {request.spend_to} - {request.amount}円
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default ApplicationsPage;

--- a/front/src/hooks/useKeihi.tsx
+++ b/front/src/hooks/useKeihi.tsx
@@ -1,0 +1,28 @@
+import axios from "axios";
+
+export interface Application {
+  id: string;
+  status: string;
+  data_of_use: string;
+  amount: number;
+  spend_to: string;
+  keihi_class: string;
+  purpose: string;
+  invoice_number?: number;
+  contact_number?: number;
+  memo?: string;
+  image_save?: string;
+  created_at: string;
+  updated_at: string;
+}
+export const fetchApplications = async (): Promise<Application[]> => {
+  try {
+    const response = await axios.get<Application[]>(
+      "http://localhost:3000/api/v1/keihi/index"
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching applications:", error);
+    throw error;
+  }
+};

--- a/front/src/pages/ContentsPage.tsx
+++ b/front/src/pages/ContentsPage.tsx
@@ -1,25 +1,23 @@
-import { useNavigate } from 'react-router-dom';
-import HeaderComponent from '../components/HeaderComponent';
-import SideBar from '../components/SideBarComponent';
-import SpendRequestForm from '../components/SpendRequestFormComponent';
-import { useAuth } from '../hooks/useAuth';
+import { useNavigate } from "react-router-dom";
+import HeaderComponent from "../components/HeaderComponent";
+import SideBar from "../components/SideBarComponent";
+import SpendRequestForm from "../components/SpendRequestFormComponent";
+import { useAuth } from "../hooks/useAuth";
 
 export const ContentsPage = () => {
   const { currentUser, token, logout, setCurrentUser } = useAuth();
   const navigate = useNavigate();
 
-
-
   if (!currentUser) {
-    navigate('/');
-  }else{
+    navigate("/");
+  } else {
     return (
       <div className="w-screen">
         <HeaderComponent />
         <div className="flex h-screen">
-          <SideBar/>
-          <SpendRequestForm/>
-        </div>  
+          <SideBar />
+          <SpendRequestForm />
+        </div>
       </div>
     );
   }

--- a/front/yarn.lock
+++ b/front/yarn.lock
@@ -512,6 +512,13 @@
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.21.0.tgz#20c09cf44dcb082140cc7f439dd679fe4bba3375"
   integrity sha512-2jsCDZwtQvRhejHLfZ1JY6w6kEuEtfF9nzYsZxzSlNVKDX+DpsDJ+Rbjkm74nvg2rdx0gwBS+IMdvwJuq3S9pQ==
 
+"@types/axios@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@types/axios/-/axios-0.14.0.tgz#ec2300fbe7d7dddd7eb9d3abf87999964cafce46"
+  integrity sha512-KqQnQbdYE54D7oa/UmYVMZKq7CO4l8DEENzOKc4aBRwxCXSlJXGz83flFx5L7AWrOQnmuN3kVsRdt+GZPPjiVQ==
+  dependencies:
+    axios "*"
+
 "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -756,7 +763,7 @@ autoprefixer@^10.4.20:
     picocolors "^1.0.1"
     postcss-value-parser "^4.2.0"
 
-axios@^1.7.4:
+axios@*, axios@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.4.tgz#4c8ded1b43683c8dd362973c393f3ede24052aa2"
   integrity sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==


### PR DESCRIPTION
## 修正・追加内容
---
seedによってランダムのテストデータが生成。
front/src/hooks/useKeihi.tsxでデータの受け取り。front/src/components/TestComponent.tsxに受け取って表示した例。


## 検証方法
---
テストデータはdocker-compose exec app rails db:seedで実行多分可能。
##  レビュしてほしいポイント
---

## 特記事項
---