### PR TITLE
[add] APIからget_by_userで申請データを取得し、SideBarに渡して表示する機能を実装,

### DIFF
--- a/front/mockdata.json
+++ b/front/mockdata.json
@@ -1,0 +1,59 @@
+[
+    {   
+        "userId": "A0001",
+        "status": "申請中",
+        "spendTo": "電車",
+        "createdAt": "2024-07-02",
+        "updatedAt": "2024-07-02",
+        "spendRequestItems": [
+            {
+                "amount": 1000,
+                "usageDate": "2024-08-30",
+                "expenseCategory": "行き"
+            },
+            {
+                "amount": 1000,
+                "usageDate": "2024-08-30",
+                "expenseCategory": "帰り"
+            }
+        ]
+    },
+    {   
+        "userId": "A0001",
+        "status": "承認待ち",
+        "spendTo": "札幌行きタクシー",
+        "createdAt": "2024-07-02",
+        "updatedAt": "2024-07-02",
+        "spendRequestItems": [
+            {
+                "amount": 2000,
+                "usageDate": "2024-08-30",
+                "expenseCategory": "行き"
+            },
+            {
+                "amount": 1000,
+                "usageDate": "2024-08-30",
+                "expenseCategory": "帰り"
+            }
+        ]
+    },
+    {   
+        "userId": "A0001",
+        "status": "承認待ち",
+        "spendTo": "ハワイ行き飛行機",
+        "createdAt": "2024-07-02",
+        "updatedAt": "2024-07-02",
+        "spendRequestItems": [
+            {
+                "amount": 1000,
+                "usageDate": "2024-08-30",
+                "expenseCategory": "行き"
+            },
+            {
+                "amount": 1000,
+                "usageDate": "2024-08-30",
+                "expenseCategory": "帰り"
+            }
+        ]
+    }
+]

--- a/front/src/components/SideBarComponent.tsx
+++ b/front/src/components/SideBarComponent.tsx
@@ -1,3 +1,10 @@
+import mockData from '../../mockdata'   // モックデータの読み込み
+
+
+interface Props {
+    keihis: SpendRequest[];
+}
+
 interface SpendRequestItem {
     amount: number;          // 金額
     usageDate: string;       // 利用日（ISO 8601形式の文字列として表現される場合）
@@ -13,107 +20,60 @@ interface SpendRequestItem {
     updatedAt: string;       // updated_at（ISO 8601形式の文字列として表現される場合）
     spendRequestItems: SpendRequestItem[]; // spend_request_item（配列型でSpendRequestItemオブジェクトのリスト）
   }
+
+
   
 
-/* モックデータ */
-const itemList : SpendRequest[]=[
-    {   
-        userId: "A0001",
-        status: "申請中",       // status（文字列型。必要に応じてリテラル型や列挙型にすることも可能）
-        spendTo: "電車",      // spend_to（文字列型。具体的な内容に応じて変更するかもしれません）
-        createdAt: "2024-7-2",       // created_at（ISO 8601形式の文字列として表現される場合）
-        updatedAt: "2024-7-2",       // updated_at（ISO 8601形式の文字列として表現される場合）
-        spendRequestItems:
-        [
-            {
-                amount: 1000,
-                usageDate: "2024-8-30",
-                expenseCategory: "行き",
-            },
-            {
-                amount: 1000,
-                usageDate: "2024-8-30",
-                expenseCategory: "帰り",
-            }
-        ]
-    },
-    {   
-        userId: "A0001",
-        status: "承認待ち",       // status（文字列型。必要に応じてリテラル型や列挙型にすることも可能）
-        spendTo: "札幌行きタクシー",      // spend_to（文字列型。具体的な内容に応じて変更するかもしれません）
-        createdAt: "2024-7-2",       // created_at（ISO 8601形式の文字列として表現される場合）
-        updatedAt: "2024-7-2",       // updated_at（ISO 8601形式の文字列として表現される場合）
-        spendRequestItems:
-        [
-            {
-                amount: 2000,
-                usageDate: "2024-8-30",
-                expenseCategory: "行き",
-            },
-            {
-                amount: 1000,
-                usageDate: "2024-8-30",
-                expenseCategory: "帰り",
-            }
-        ]    },
-    {   
-        userId: "A0001",
-        status: "承認待ち",       // status（文字列型。必要に応じてリテラル型や列挙型にすることも可能）
-        spendTo: "ハワイ行き飛行機",      // spend_to（文字列型。具体的な内容に応じて変更するかもしれません）
-        createdAt: "2024-7-2",       // created_at（ISO 8601形式の文字列として表現される場合）
-        updatedAt: "2024-7-2",       // updated_at（ISO 8601形式の文字列として表現される場合）
-        spendRequestItems:
-        [
-            {
-                amount: 1000,
-                usageDate: "2024-8-30",
-                expenseCategory: "行き",
-            },
-            {
-                amount: 1000,
-                usageDate: "2024-8-30",
-                expenseCategory: "帰り",
-            }
-        ]
-    }
-]
 
-// 経費合計の計算をする関数
+
+/* 経費合計の計算をする関数 */
 function calculateTotalAmount(items: SpendRequestItem[]): number {
     return items.reduce((total, item) => total + item.amount, 0);
 }
 
-//  className="fixed top-0 left-0 z-40 w-80 h-screen transition-transform -translate-x-full sm:translate-x-0" aria-label="Sidebar"
-//  className="h-full px-3 py-4 overflow-y-auto bg-gray-50 dark:bg-gray-800 flex flex-col gap-1"
+/* 状態をフォーマットする */
+// function formatStatus(status: string):string{
+//     if(status==="pending"){
+//         return "申請中"
+//     }
+//     else if(status==="")
+//     return
+// }
 
-const SideBar = () =>{
+/* created_atをフォーマットする*/
+function formatCreatedAt(created_at: string):string{
+    const datas=created_at.split('-')
+    return datas[0]+'年'+datas[1]+'月'+datas[2].slice(0,2)+'日'
+}
+
+
+const SideBar = ({keihis}) =>{
     return (
         <div className="w-80 px-3 h-full bg-gray-200 ">
             <div className="my-5 w-full flex justify-center">
                 <button className="bg-yellow-300  w-64">新規作成</button>
             </div>
-            
             <div className=" h-overflow-y-hidden">
             {(() => {
                 const items = [];
                 // items.push(<button className="bg-yellow-300">新規作成</button>)
-                for (let i = 0; i < itemList.length; i++) {
+                for (let i = 0; i < keihis.length; i++) {
                     items.push(<button className="h-28 w-full flex justify-between items-center shadow rounded cursor-pointer border border-transparent">
                         <div className="w-full flex flex-col">
                             <div className="w-full flex flex-row">
                                 <div className="w-1/3">
-                                    {itemList[i].status}
+                                    {keihis[i].status}
                                 </div>
                                 <div className="w-full right-0">
-                                    {itemList[i].createdAt}
+                                    {formatCreatedAt(keihis[i].created_at)}
                                 </div>
                             </div>
                             <div className="w-full flex flex-row">
                                 <div className="w-1/3 truncate ">
-                                  {itemList[i].spendTo}
+                                  {keihis[i].spend_to}
                                 </div>
                                 <div className="w-full right-0">
-                                    {calculateTotalAmount(itemList[i].spendRequestItems)}
+                                    {calculateTotalAmount(keihis[i].spend_request_item)}円
                                 </div>
                             </div>
                         </div>
@@ -127,8 +87,6 @@ const SideBar = () =>{
             })()}
             </div>
         </div>
-        // <div className="w-96 bg-blue-100"><p>aaa</p></div>
-
     )
 }
 

--- a/front/src/pages/ContentsPage.tsx
+++ b/front/src/pages/ContentsPage.tsx
@@ -1,12 +1,41 @@
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import HeaderComponent from '../components/HeaderComponent';
 import SideBar from '../components/SideBarComponent';
 import SpendRequestForm from '../components/SpendRequestFormComponent';
 import { useAuth } from '../hooks/useAuth';
 
+
+const API_URL = 'http://localhost:3000/api/v1';
+
+
 export const ContentsPage = () => {
   const { currentUser, token, logout, setCurrentUser } = useAuth();
   const navigate = useNavigate();
+  
+  const [keihis, setKeihis] = useState<any[]>([]);
+  
+  
+  /* ------------------- */
+  useEffect(()=>{
+    
+    console.log(currentUser)
+    if(token){
+      fetch(`${API_URL}/keihi/get_by_user?user_id=${currentUser.id}`, {
+        method: 'GET',
+      })
+      .then((response) => response.json()) // 必要に応じてJSONをパース
+      .then((data)=>{
+        setKeihis(data)
+      })
+      .catch((error) => {
+        console.error("Error fetching current user", error);
+        logout();
+      });
+    }
+  },[]);
+
+  /* ------------------- */
 
   if (!currentUser) {
     navigate('/');
@@ -15,7 +44,8 @@ export const ContentsPage = () => {
       <div className="w-screen h-screen flex flex-col">
         <HeaderComponent />
         <div className="flex flex-grow">
-          <SideBar />
+          {/* サイドバーにkeihiのpropsを渡す */}
+          <SideBar keihis={keihis}/>
           <div className="flex-grow">
             <SpendRequestForm />
           </div>


### PR DESCRIPTION
## 修正・追加内容
- front/src/pages/ContentsPage.tsxでAPIを叩いてログイン中のuserによる申請を全て取得
- 取得したデータ(keihis)をsrc/componetns/SideBar.tsxに渡す
- SideBarコンポーネント内で適当な形にフォーマットして表示する
- SideBarコンポーネントで使用したmockdataを front/mockdata.jsonに退避
## 検証方法

##  レビュしてほしいポイント
- サイドバーないの申請内容カード（ボタン）のデザインは要検討

## 特記事項
- 取得データの変数名がkeihis（適当）なので、後で変更する
- useEffect、APIを叩いている部分は、hooksに移動予定
